### PR TITLE
Make Builder accept normal function arguments

### DIFF
--- a/examples/adder/adder_cli.py
+++ b/examples/adder/adder_cli.py
@@ -2,8 +2,8 @@ import orco
 
 
 @orco.builder()
-def add(config):
-    return config["a"] + config["b"]
+def add(a, b):
+    return a + b
 
 
 orco.run_cli()

--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -5,16 +5,16 @@ import orco
 
 
 @orco.builder()
-def do_something(config):
+def do_something(_unused):
     time.sleep(0.3)  # Simulate computation
     return random.randint(0, 10)
 
 
 @orco.builder()
-def make_experiment(config):
-    data = [do_something(x) for x in range(config["difficulty"])]
+def make_experiment(difficulty):
+    data = [do_something(x) for x in range(difficulty)]
     yield
-    time.sleep(config["difficulty"])  # Simulate computation
+    time.sleep(difficulty)  # Simulate computation
     return sum(entry.value for entry in data)
 
 

--- a/examples/tournament/tournament.py
+++ b/examples/tournament/tournament.py
@@ -1,51 +1,52 @@
 import itertools
 import random
+import collections
 
 import orco
 
 
+Player = collections.namedtuple("Player", ["strength"])
+
 # Function that trains "players"
 @orco.builder()
-def train_player(config):
-    # We will simulate trained players by a dictionary with a "strength" key
-    return {"strength": random.randint(0, 10)}
+def train_player(_player_name):
+    # We will simulate trained players by a simple object with "strength"
+    return Player(strength=random.randint(0, 10))
 
 
 # Build function for "games"
 @orco.builder()
-def play_game(config):
-    player1 = train_player(config["player1"])
-    player2 = train_player(config["player2"])
+def play_game(p1, p2):
+    player1 = train_player(p1)
+    player2 = train_player(p2)
     yield
 
     # Simulation of playing a game between two players,
     # They just throw k-sided dices, where k is trength of the player
     # The difference of throw is the result
 
-    r1 = random.randint(0, player1.value["strength"] * 2)
-    r2 = random.randint(0, player2.value["strength"] * 2)
+    r1 = random.randint(0, player1.value.strength * 2)
+    r2 = random.randint(0, player2.value.strength * 2)
     return r1 - r2
 
 
 # Build function for a tournament, return score for each player
 @orco.builder()
-def play_tournament(config):
+def play_tournament(players):
     # For evaluating a tournament, we need to know the results of games between
     # each pair of its players.
-    games = [
-        play_game({"player1": p1, "player2": p2})
-        for (p1, p2) in itertools.product(config["players"], config["players"])
-    ]
+    games = {
+        (p1, p2): play_game(p1, p2)
+        for (p1, p2) in itertools.product(players, players)
+    }
     yield
 
     score = {}
-    for game in games:
-        player1 = game.config["player1"]
-        player2 = game.config["player2"]
-        score.setdefault(player1, 0)
-        score.setdefault(player2, 0)
-        score[player1] += game.value
-        score[player2] -= game.value
+    for (p1, p2), game in games.items():
+        score.setdefault(p1, 0)
+        score.setdefault(p2, 0)
+        score[p1] += game.value
+        score[p2] -= game.value
     return score
 
 

--- a/orco/builder.py
+++ b/orco/builder.py
@@ -78,11 +78,19 @@ class Builder:
 
     def __call__(self, *args, **kwargs):
         """
-        Create an unresolved Entry for this builder.
+        Create an unresolved Entry for this builder from function arguments.
 
         Calls `_CONTEXT.on_entry` to register/check dependencies etc.
         """
         config = self._create_config_from_call(args, kwargs)
+        return self.from_config(config)
+
+    def from_config(self, config):
+        """
+        Create an unresolved Entry for this builder from config dict.
+
+        Calls `_CONTEXT.on_entry` to register/check dependencies etc.
+        """
         entry = Entry(self.name, make_key(config), config, None, None, None)
         if not hasattr(_CONTEXT, "on_entry"):
             return entry

--- a/orco/builder.py
+++ b/orco/builder.py
@@ -56,7 +56,11 @@ class Builder:
             functools.update_wrapper(self, fn)
 
     def _create_config_from_call(self, args, kwargs):
-        "Return an OrderedDIct of named parameters, unpacking extra kwargs into the dict."
+        """
+        Return an OrderedDIct of named parameters, unpacking extra kwargs into the dict.
+        """
+        if self.main_fn is None and args:
+            raise Exception("Builders with fn=None only accept keyword arguments")
         ba = self.fn_signature.bind(*args, **kwargs)
         ba.apply_defaults()
         kwnames = [p.name for p in self.fn_signature.parameters.values() if p.kind == p.VAR_KEYWORD]

--- a/orco/cfggen.py
+++ b/orco/cfggen.py
@@ -1,7 +1,7 @@
 import collections
 import itertools
 import json
-from collections import Iterable
+from collections.abc import Iterable
 
 _State = collections.namedtuple("State", ["toplevel", "computed", "resolving"])
 

--- a/orco/cli.py
+++ b/orco/cli.py
@@ -12,7 +12,7 @@ def _command_serve(runtime, args):
 
 def _command_compute(runtime, args):
     builder = runtime._get_builder(args.builder)
-    task = Builder(builder)(json.loads(args.config))
+    task = Builder(builder)(**json.loads(args.config))
     print(runtime.compute(task).value)
 
 

--- a/orco/cli.py
+++ b/orco/cli.py
@@ -12,7 +12,7 @@ def _command_serve(runtime, args):
 
 def _command_compute(runtime, args):
     builder = runtime._get_builder(args.builder)
-    task = builder.run_with_config(json.loads(args.config))
+    task = builder.from_config(json.loads(args.config))
     print(runtime.compute(task).value)
 
 

--- a/orco/cli.py
+++ b/orco/cli.py
@@ -12,7 +12,7 @@ def _command_serve(runtime, args):
 
 def _command_compute(runtime, args):
     builder = runtime._get_builder(args.builder)
-    task = Builder(builder)(**json.loads(args.config))
+    task = builder.run_with_config(json.loads(args.config))
     print(runtime.compute(task).value)
 
 

--- a/orco/entry.py
+++ b/orco/entry.py
@@ -6,7 +6,7 @@ class Entry:
     A single computation with its configuration and result
 
     Attributes
-    * config - `OrderedDict` of function parameters (i.e. usable as `f(**config)`)
+    * config - `OrderedDict` of function parameters (use with `Builder.run_with_config`)
     * value - resulting value of the computation
     * job_setup - setup for the job
     * created - datetime when entry was created

--- a/orco/entry.py
+++ b/orco/entry.py
@@ -6,7 +6,7 @@ class Entry:
     A single computation with its configuration and result
 
     Attributes
-    * config - configuration
+    * config - `OrderedDict` of function parameters (i.e. usable as `f(**config)`)
     * value - resulting value of the computation
     * job_setup - setup for the job
     * created - datetime when entry was created

--- a/orco/export.py
+++ b/orco/export.py
@@ -1,10 +1,24 @@
 import pandas as pd
 
 
-def export_builder_to_pandas(runtime, builder_name):
+def export_builder_to_pandas(runtime, builder_name, missing=pd.NA, arg_prefix="arg."):
     """
     Export builder into pandas  DataFrame
     """
-    data = [(entry.config, entry.value, entry.comp_time)
-            for entry in runtime.db.get_all_entries(builder_name)]
-    return pd.DataFrame(data, columns=["config", "value", "comp_time"])
+    cols = {"value": [], "comp_time": []}
+    for i, entry in enumerate(runtime.db.get_all_entries(builder_name)):
+        cols["value"].append(entry.value)
+        cols["comp_time"].append(entry.comp_time)
+        for k, v in entry.config.items():
+            n = arg_prefix + k
+            if n not in cols:
+                cols[n] = [missing] * i
+            c = cols[n]
+            if len(c) != i:
+                c.extend([missing] * (i - len(c)))
+            c.append(v)
+    n = len(cols["value"])
+    for c in cols.values():
+        if len(c) != n:
+            c.extend([missing] * (n - len(c)))
+    return pd.DataFrame(cols)

--- a/orco/export.py
+++ b/orco/export.py
@@ -5,6 +5,7 @@ def export_builder_to_pandas(runtime, builder_name, missing=pd.NA, arg_prefix="a
     """
     Export builder into pandas  DataFrame
     """
+
     cols = {"value": [], "comp_time": []}
     for i, entry in enumerate(runtime.db.get_all_entries(builder_name)):
         cols["value"].append(entry.value)

--- a/orco/internals/runner.py
+++ b/orco/internals/runner.py
@@ -119,7 +119,7 @@ def _run_job(db_path, fns, entry_key, config, dep_keys, job_setup):
                 if inspect.isgeneratorfunction(main_fn):
                     deps = []
                     _CONTEXT.on_entry = deps.append
-                    it = main_fn(config)
+                    it = main_fn(**config)
                     next(it)
                     if set(e.make_entry_key() for e in deps) != set(dep_keys):
                         raise Exception("Builder function does not consistently return dependencies")
@@ -133,7 +133,7 @@ def _run_job(db_path, fns, entry_key, config, dep_keys, job_setup):
                         value = e.value
                 else:
                     _CONTEXT.on_entry = block_new_entries
-                    value = main_fn(config)
+                    value = main_fn(**config)
             finally:
                 _CONTEXT.on_entry = None
             end_time = time.time()

--- a/orco/runtime.py
+++ b/orco/runtime.py
@@ -229,7 +229,7 @@ class Runtime:
                 deps = []
                 try:
                     _CONTEXT.on_entry = deps.append
-                    it = builder.main_fn(**entry.config)
+                    it = builder.run_with_config(entry.config)
                     next(it)
                 except StopIteration:
                     raise Exception(

--- a/orco/runtime.py
+++ b/orco/runtime.py
@@ -6,6 +6,7 @@ import threading
 import time
 
 from orco.internals.context import _CONTEXT
+
 from .builder import Builder
 from .entry import Entry
 from .internals.db import DB
@@ -228,7 +229,7 @@ class Runtime:
                 deps = []
                 try:
                     _CONTEXT.on_entry = deps.append
-                    it = builder.main_fn(entry.config)
+                    it = builder.main_fn(**entry.config)
                     next(it)
                 except StopIteration:
                     raise Exception(

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3,8 +3,18 @@ import pytest
 from orco import Builder, builder
 
 
-def adder(config):
-    return config["a"] + config["b"]
+def adder(a, b):
+    return a + b
+
+
+def test_builder_args(env):
+    @builder()
+    def f(a, *ars, e=2, **kwrs):
+        return (a, ars, e, kwrs)
+
+    runtime = env.test_runtime()
+    assert runtime.compute(f(1)).value == (1, (), 2, {})
+    assert runtime.compute(f(1, 2, 3, 4, f=3)).value == (1, (2, 3, 4), 2, {'f': 3})
 
 
 def test_builder_init(env):

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -12,9 +12,18 @@ def test_builder_args(env):
     def f(a, *ars, e=2, **kwrs):
         return (a, ars, e, kwrs)
 
+    @builder()
+    def g(a, *ars, e=2, **kwrs):
+        d = f(a, *ars, e=e, **kwrs)
+        yield
+        return d.value
+
     runtime = env.test_runtime()
     assert runtime.compute(f(1)).value == (1, (), 2, {})
     assert runtime.compute(f(1, 2, 3, 4, f=3)).value == (1, (2, 3, 4), 2, {'f': 3})
+    assert runtime.compute(f(e=3, a=42)).value == (42, (), 3, {})
+
+    assert runtime.compute(g(1, 2, 3, 4, f=3)).value == (1, (2, 3, 4), 2, {'f': 3})
 
 
 def test_builder_init(env):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,16 +18,16 @@ def test_db_announce(env):
     e2.start()
 
     c = r.register_builder(Builder(None, "col1"))
-    assert r.db.announce_entries(e1.id, [c("test1"), c("test2")], [])
-    assert not r.db.announce_entries(e2.id, [c("test2"), c("test3")], [])
-    assert not r.db.announce_entries(e1.id, [c("test2"), c("test3")], [])
-    assert r.db.announce_entries(e2.id, [c("test3")], [])
-    assert r.db.get_entry_state(c.name, make_key("test1")) == "announced"
+    assert r.db.announce_entries(e1.id, [c(x="test1"), c(x="test2")], [])
+    assert not r.db.announce_entries(e2.id, [c(x="test2"), c(x="test3")], [])
+    assert not r.db.announce_entries(e1.id, [c(x="test2"), c(x="test3")], [])
+    assert r.db.announce_entries(e2.id, [c(x="test3")], [])
+    assert r.db.get_entry_state(c.name, make_key({'x': "test1"})) == "announced"
     time.sleep(3)
-    assert r.db.get_entry_state(c.name, make_key("test1")) is None
-    assert not r.db.announce_entries(e2.id, [c("test2"), c("test3")], [])
-    assert r.db.announce_entries(e2.id, [c("test2")], [])
-    assert not r.db.announce_entries(e2.id, [c("test2")], [])
+    assert r.db.get_entry_state(c.name, make_key({'x': "test1"})) is None
+    assert not r.db.announce_entries(e2.id, [c(x="test2"), c(x="test3")], [])
+    assert r.db.announce_entries(e2.id, [c(x="test2")], [])
+    assert not r.db.announce_entries(e2.id, [c(x="test2")], [])
 
 
 def make_raw_entry(runtime, c, cfg, value, comp_time=1):
@@ -41,34 +41,34 @@ def test_db_set_value(env):
     e1 = r.start_executor()
 
     c = r.register_builder(Builder(None, "col1"))
-    assert r.db.get_entry_state(c.name, make_key("cfg1")) is None
+    assert r.db.get_entry_state(c.name, make_key({'a': "cfg1"})) is None
 
-    r.db.announce_entries(e1.id, [c("cfg1")], [])
-    assert r.db.get_entry_state(c.name, make_key("cfg1")) == "announced"
+    r.db.announce_entries(e1.id, [c(a="cfg1")], [])
+    assert r.db.get_entry_state(c.name, make_key({'a': "cfg1"})) == "announced"
 
-    assert r.try_read_entry(c("cfg1")) is None
-    assert r.try_read_entry(c("cfg1"), include_announced=True) is not None
+    assert r.try_read_entry(c(a="cfg1")) is None
+    assert r.try_read_entry(c(a="cfg1"), include_announced=True) is not None
 
-    e = make_raw_entry(r, c, "cfg1", "value1")
+    e = make_raw_entry(r, c, {'a':'cfg1'}, "value1")
     r.db.set_entry_values(e1.id, [e])
-    assert r.db.get_entry_state(c.name, make_key("cfg1")) == "finished"
+    assert r.db.get_entry_state(c.name, make_key({'a':"cfg1"})) == "finished"
 
-    assert r.try_read_entry(c("cfg1")) is not None
-    assert r.try_read_entry(c("cfg1"), include_announced=True) is not None
+    assert r.try_read_entry(c(a="cfg1")) is not None
+    assert r.try_read_entry(c(a="cfg1"), include_announced=True) is not None
 
     with pytest.raises(Exception):
         r.db.set_entry_values(e1.id, [e])
 
-    e2 = make_raw_entry(r, c, "cfg2", "value2")
+    e2 = make_raw_entry(r, c, {'a':'cfg2'}, "value2")
     with pytest.raises(Exception):
         r.db.set_entry_values(e1.id, [e2])
-    r.db.announce_entries(e1.id, [c("cfg2")], [])
+    r.db.announce_entries(e1.id, [c(a="cfg2")], [])
     r.db.set_entry_values(e1.id, [e2])
 
     with pytest.raises(Exception):
         r.db.create_entries([e2])
 
-    e3 = make_raw_entry(r, c, "cfg3", "value3")
+    e3 = make_raw_entry(r, c, {'a':'cfg3'}, "value3")
     r.db.create_entries([e3])
 
 
@@ -81,17 +81,17 @@ def test_db_run_stats(env):
     _ = runtime.register_builder(Builder(None, "col2"))
 
     assert runtime.db.announce_entries(
-        e1.id, [c("a"), c("b"), c("c"),
-                c("d"), c("e")], [])
-    assert runtime.db.get_entry_state(c.name, make_key("a")) == "announced"
+        e1.id, [c(x="a"), c(x="b"), c(x="c"),
+                c(x="d"), c(x="e")], [])
+    assert runtime.db.get_entry_state(c.name, make_key({'x': "a"})) == "announced"
     runtime.db._dump()
-    entry = make_raw_entry(runtime, c, "a", "value", comp_time=1)
+    entry = make_raw_entry(runtime, c, {'x': "a"}, "value", comp_time=1)
     runtime.db.set_entry_values(e1.id, [entry])
-    entry = make_raw_entry(runtime, c, "b", "value", comp_time=2)
+    entry = make_raw_entry(runtime, c, {'x': "b"}, "value", comp_time=2)
     runtime.db.set_entry_values(e1.id, [entry])
-    entry = make_raw_entry(runtime, c, "c", "value", comp_time=3)
+    entry = make_raw_entry(runtime, c, {'x': "c"}, "value", comp_time=3)
     runtime.db.set_entry_values(e1.id, [entry])
-    entry = make_raw_entry(runtime, c, "d", "value", comp_time=4)
+    entry = make_raw_entry(runtime, c, {'x': "d"}, "value", comp_time=4)
     runtime.db.set_entry_values(e1.id, [entry])
 
     r = runtime.db.get_run_stats("col1")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,6 @@
 from orco import Builder
 from orco.export import export_builder_to_pandas
+import pandas as pd
 
 
 def test_builder_to_pandas(env):
@@ -9,7 +10,28 @@ def test_builder_to_pandas(env):
     runtime.compute_many([col1(x) for x in [1, 2, 3, 4]])
     frame = export_builder_to_pandas(runtime, col1.name)
     assert len(frame) == 4
-    assert sorted(frame["config"]) == [1, 2, 3, 4]
+    assert sorted(frame["arg.c"]) == [1, 2, 3, 4]
     assert sorted(frame["value"]) == [2, 4, 6, 8]
 
-    assert frame[frame["config"] == 1]["value"].iloc[0] == 2
+    assert frame[frame["arg.c"] == 1]["value"].iloc[0] == 2
+
+
+def test_builder_to_pandas_kwargs(env):
+    runtime = env.test_runtime()
+
+    def foo(a=1, **kwargs):
+        return a + sum(kwargs.values())
+
+    foob = runtime.register_builder(Builder(foo))
+    runtime.compute(foob(b=2))
+    runtime.compute(foob(a=3))
+    runtime.compute(foob(42, b=1, c=8))
+    frame = export_builder_to_pandas(runtime, foob.name)
+    frame.sort_values("arg.a")
+    frame.fillna(value=999, inplace=True)
+
+    assert len(frame) == 3
+    assert list(frame["arg.a"]) == [1, 3, 42]
+    assert list(frame["arg.b"]) == [2, 999, 1]
+    assert list(frame["arg.c"]) == [999, 999, 8]
+    assert list(frame["value"]) == [3, 3, 51]

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -12,8 +12,8 @@ def test_rest_builders():
 
         c = rt.register_builder(Builder(None, "hello"))
 
-        rt.insert(c({"x": 1, "y": [1, 2, 3]}), "ABC")
-        rt.insert(c("e2"), "A" * (1024 * 1024))
+        rt.insert(c(x=1, y=[1, 2, 3]), "ABC")
+        rt.insert(c(e="e2"), "A" * (1024 * 1024))
 
         rt.register_builder(Builder(None, "hello2"))
 
@@ -35,7 +35,7 @@ def test_rest_builders():
             assert item.get("size")
             del item["size"]
         assert len(rr) == 2
-        assert rr[0]["config"] == "e2"
+        assert rr[0]["config"] == {'e': "e2"}
         assert rr[1]["config"] == {'x': 1, 'y': [1, 2, 3]}
 
 


### PR DESCRIPTION
In short, you can now write 

```python
@orco.builder()
def strange_add(x, y, *args, bias=0):
    b = some_other_builder(42, foo=[1,2,3])
    yield
    return b.value + x + y + sum(args) + bias

entry = strange_add(3, 5, 9, 13, bias=-1)
```

One feature is that `config` (and therefore also `key`) is a dictionary of all the arguments (even the positional ones and additional kwargs) so it should be well-readable.

Only extra positional args are passed under the `*args` key (`args` name taken from the function definition). (It took a bit of work to make it work with dict config, but is IMO preferable to e.g. having config being just tuple of `(positional_args, kwargs)` as that would lose a lot of information about args names.

Also adds argument columns to pandas export instead of just `config`: argument columns are named `arg.param_name` by default. Extra keyword arguments are added as columns with `pandas.NA` where not given.

NOTE: This PR does not update docs yet (in case of comments).

### Commits


Change Builder to be called with arguments
   
* Builder functions can now accept positional and keyword arguments,
  even with defaults, *args and **kwargs
* Entry keys contain all default parameter values
* Fixed builders accept only keyword arguments
  (without function signature, args and kwargs can not be distinguished)

Update pandas export to have one column per argument

* Columns are named "arg.XXX" by default
* Non-present values are filled with pandas.NA by default

Update tests for builders with parameters

Fix cli runner and examples to use the new calling 

Fixed *args handling

Extend complex builder argumnts test

Fix cli runner (also fixes examples)

