### PR TITLE
Add bool to enabled key types (for clarity)

### DIFF
--- a/orco/internals/key.py
+++ b/orco/internals/key.py
@@ -1,5 +1,5 @@
 def _make_key_helper(obj, stream):
-    if isinstance(obj, str) or isinstance(obj, int) or isinstance(obj, float):
+    if isinstance(obj, (str, int, float, bool)):
         stream.append(repr(obj))
     elif isinstance(obj, list) or isinstance(obj, tuple):
         stream.append("[")
@@ -11,8 +11,7 @@ def _make_key_helper(obj, stream):
         stream.append("{")
         for key, value in sorted(obj.items()):
             if not isinstance(key, str):
-                raise Exception("Invalid key in config: '{}', type: {}".format(
-                    repr(key), type(key)))
+                raise Exception("Invalid key in config: {!r}, type: {}".format(key, type(key)))
             if key.startswith("_"):
                 continue
             stream.append(repr(key))
@@ -21,7 +20,7 @@ def _make_key_helper(obj, stream):
             stream.append(",")
         stream.append("}")
     else:
-        raise Exception("Invalid item in config: '{}', type: {}".format(repr(obj), type(obj)))
+        raise Exception("Invalid item in config: {!r}, type: {}".format(obj, type(obj)))
 
 
 def make_key(config):

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -6,6 +6,7 @@ from orco.internals.key import make_key
 def test_make_key_basics():
     assert make_key(10) == "10"
     assert make_key("Hello!") == "'Hello!'"
+    assert make_key("\'\"Hello!") == "'\\'\"Hello!'"
     assert make_key(3.14) == "3.14"
     assert make_key([True, False, 2]) == "[True,False,2,]"
 


### PR DESCRIPTION
Was supposed to fix #21 but turns out these were covered by `bool` being an instance of `int` (?!?). Still putting this here since it adds some clarity. :man_shrugging: 