### PR TITLE
QoL improvements, pickling and _run_job overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test_simple:
 test_adder:
 	rm -f "$(EXAMPLE_DB)"
 	PYTHONPATH=. python examples/adder/adder_cli.py --db "$(EXAMPLE_DB)" \
-		compute add '{"a": 1, "b": 2}'
+		compute add '{"$$product": {"a": [0,100], "b": {"$$range": 3}}}'
 	rm -f "$(EXAMPLE_DB)"
 
 test_tournament:

--- a/orco/builder.py
+++ b/orco/builder.py
@@ -165,6 +165,9 @@ class Builder:
             return False
         return self.name == other.name
 
+    def __hash__(self):
+        return hash((3726138, self.name))
+
     def __repr__(self):
         return "<{} {!r}>".format(self.__class__.__name__, self.name)
 

--- a/orco/builder.py
+++ b/orco/builder.py
@@ -121,7 +121,8 @@ class Builder:
         Correctly handles both generator and ordinary main functions, returning the
         final value. With `only_deps=True` only executes the part until `yield`
         (or nothing for ordinary functions).
-        Does not set the context etc.
+
+        If given, runs after_deps() after the dependency phase. Does not set the context etc.
         """
         if self.fn is None:
             raise Exception("Fixed builder {!r} can't be run".format(self))

--- a/orco/builder.py
+++ b/orco/builder.py
@@ -36,7 +36,7 @@ class Builder:
     function (name, doc, etc.).
     """
 
-    def __init__(self, fn, name: str = None, job_setup=None, update_wrapper=False):
+    def __init__(self, fn, name: str = None, job_setup=None):
         if not callable(fn) and fn is not None:
             raise TypeError("Fn must be callable or None, {!r} provided".format(fn))
 
@@ -67,8 +67,10 @@ class Builder:
             self.fn_signature = inspect.signature(_generic_kwargs_fn)
             self.fn_argspec = inspect.getfullargspec(_generic_kwargs_fn)
 
-        if update_wrapper and self.fn:
-            functools.update_wrapper(self, self.fn)
+        self.__signature__ = self.fn_signature
+        if hasattr(self.fn, '__name__'):
+            self.__name__ = self.fn.__name__
+        self.__doc__ = "Builder {!r} for {!r}, original docs:\n\n{}\nBuilde class doc:\n\n{}".format(self.name, self.fn, self.fn.__doc__, self.__doc__)
 
     @property
     def fn(self):

--- a/orco/entry.py
+++ b/orco/entry.py
@@ -34,7 +34,14 @@ class Entry:
         return EntryKey(self.builder_name, self.key)
 
     def __repr__(self):
-        return "<Entry {}/{}>".format(self.builder_name, self.config)
+        return "<Entry {}/{}>".format(self.builder_name, self.key)
 
+    def __eq__(self, other):
+        if not isinstance(other, Entry):
+            return False
+        return self.make_entry_key() == other.make_entry_key()
+
+    def __hash__(self):
+        return hash((self.make_entry_key()))
 
 EntryKey = collections.namedtuple("EntryKey", ("builder_name", "key"))

--- a/orco/globals.py
+++ b/orco/globals.py
@@ -5,7 +5,7 @@ _global_builders = {}
 
 def builder(*, name=None, job_setup=None):
     def _register(fn):
-        b = Builder(fn, name=name, job_setup=job_setup, update_wrapper=True)
+        b = Builder(fn, name=name, job_setup=job_setup)
         _register_builder(b)
         return b
 

--- a/orco/internals/executor.py
+++ b/orco/internals/executor.py
@@ -130,7 +130,7 @@ class Executor:
             runner_name = job_setup.get("runner", "local")
         runner = self.runners.get(runner_name)
         if runner is None:
-            raise Exception("Task '{}' asked for runner unknown runner '{}'".format(job.entry, runner_name))
+            raise Exception("Task '{}' asked for unknown runner '{}'".format(job.entry, runner_name))
         return runner.submit(self.runtime, job)
 
     def run(self, all_jobs, continue_on_error):

--- a/orco/internals/utils.py
+++ b/orco/internals/utils.py
@@ -16,3 +16,45 @@ def unpack_frame(frame, unpack_column="config"):
     new = pd.concat([frame, new], axis=1)
     new.drop(unpack_column, inplace=True, axis=1)
     return new
+
+import inspect
+import cloudpickle
+
+class CloudWrapper:
+    """
+    Wraps a callable so that cloudpickle is used to pickle it, caching the pickle.
+    """
+    def __init__(self, fn, pickled_fn=None, cache=True, protocol=cloudpickle.DEFAULT_PROTOCOL):
+        if fn is None:
+            if pickled_fn is None:
+                raise ValueError("Pass at least one of `fn` and `pickled_fn`")
+            fn = cloudpickle.loads(pickled_fn)
+        assert callable(fn)
+        # Forget pickled_fn if it should not be cached
+        if pickled_fn is not None and not cache:
+            pickled_fn = None
+
+        self.fn = fn
+        self.pickled_fn = pickled_fn
+        self.cache = cache
+        self.protocol = protocol
+        self.__doc__ = "CloudWrapper for {!r}. Original doc:\n\n{}".format(self.fn, self.fn.__doc__)
+
+    def __repr__(self):
+        return "<{}({!r})>".format(self.__class__.__name__, self.fn)
+
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+    def _get_pickled_fn(self):
+        "Get cloudpickled version of self.fn, optionally caching the result"
+        if self.pickled_fn is not None:
+            return self.pickled_fn
+        print("Pickling {!r}".format(self))
+        pfn = cloudpickle.dumps(self.fn, protocol=self.protocol)
+        if self.cache:
+            self.pickled_fn = pfn
+        return pfn
+
+    def __reduce__(self):
+        return (self.__class__, (None, self._get_pickled_fn(), self.cache, self.protocol))

--- a/orco/internals/utils.py
+++ b/orco/internals/utils.py
@@ -20,6 +20,7 @@ def unpack_frame(frame, unpack_column="config"):
 import inspect
 import cloudpickle
 
+
 class CloudWrapper:
     """
     Wraps a callable so that cloudpickle is used to pickle it, caching the pickle.
@@ -33,28 +34,36 @@ class CloudWrapper:
         # Forget pickled_fn if it should not be cached
         if pickled_fn is not None and not cache:
             pickled_fn = None
+        if inspect.isasyncgen(fn):
+            raise TypeError("async functions not supported")
 
         self.fn = fn
         self.pickled_fn = pickled_fn
         self.cache = cache
         self.protocol = protocol
         self.__doc__ = "CloudWrapper for {!r}. Original doc:\n\n{}".format(self.fn, self.fn.__doc__)
+        if hasattr(self.fn, '__name__'):
+            self.__name__ = self.fn.__name__
+        self.__signature__ = inspect.signature(self.fn)
+
+    def is_generator_function(self):
+        return inspect.isgeneratorfunction(self.fn)
 
     def __repr__(self):
         return "<{}({!r})>".format(self.__class__.__name__, self.fn)
-
-    def __call__(self, *args, **kwargs):
-        return self.fn(*args, **kwargs)
 
     def _get_pickled_fn(self):
         "Get cloudpickled version of self.fn, optionally caching the result"
         if self.pickled_fn is not None:
             return self.pickled_fn
-        print("Pickling {!r}".format(self))
         pfn = cloudpickle.dumps(self.fn, protocol=self.protocol)
         if self.cache:
             self.pickled_fn = pfn
         return pfn
 
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
     def __reduce__(self):
         return (self.__class__, (None, self._get_pickled_fn(), self.cache, self.protocol))
+

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -30,10 +30,12 @@ def test_builder_args(env):
 
 
 def test_pickle_builder():
+    @builder()
     def f(x):
         return x + 1
 
-    bf = Builder(f)
+    bf = f
+    print(f)
     s = pickle.dumps(bf)
     f2 = pickle.loads(s)
     assert f2.run_with_config({'x': 42}) == 43
@@ -44,12 +46,12 @@ def test_builder_init(env):
 
     @builder(name="foo")
     def bar(conf):
-        "Test doc"
+        "bleurghsff"
         return conf
 
     assert bar.name == "foo"
     assert bar.__name__ == "bar"
-    assert bar.__doc__ == "Test doc"
+    assert "bleurghsff" in bar.__doc__
 
     @builder()
     def baz(conf):

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,4 +1,5 @@
 import pickle
+import random
 
 import pytest
 
@@ -439,14 +440,14 @@ def test_builder_ref_in_compute(env):
 
 def test_builder_inconsistent_deps(env):
     def builder_fn():
-        import random
-        col0(random.random())
+        c = col0(random.random())
+        print("C", c)
         yield
-        col0(123)
-        return 123
+        return c.value + 1
 
     runtime = env.test_runtime()
     col0 = runtime.register_builder(Builder(lambda c: 123, "col0"))
     bld = runtime.register_builder(Builder(builder_fn, "col1"))
+    
     with pytest.raises(Exception, match="dependencies"):
         runtime.compute(bld())

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 from orco import Builder, builder
@@ -24,6 +26,17 @@ def test_builder_args(env):
     assert runtime.compute(f(e=3, a=42)).value == (42, (), 3, {})
 
     assert runtime.compute(g(1, 2, 3, 4, f=3)).value == (1, (2, 3, 4), 2, {'f': 3})
+
+
+def test_pickle_builder():
+    def f(x):
+        return x + 1
+
+    bf = Builder(f)
+    s = pickle.dumps(bf)
+    f2 = pickle.loads(s)
+    assert f2.run_with_config({'x': 42}) == 43
+    assert f2.run_with_args((44, ), {}) == 45
 
 
 def test_builder_init(env):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import inspect
 import pickle
 
 import pandas as pd
@@ -80,6 +81,22 @@ def test_cloudwrapper():
     with pytest.raises(AttributeError):
         pickle.dumps(fn1)
 
+
+def test_cloudwrapper_generator():
+    def f(x):
+        return x + 1
+
+    cf = CloudWrapper(f)
+    assert not cf.is_generator_function()
+    assert not inspect.isgenerator(cf(1))
+
+    def g(x):
+        yield x + 2
+        return x + 3
+
+    cg = CloudWrapper(g)
+    assert cg.is_generator_function()
+    assert inspect.isgenerator(cg(1))
 
 
 def test_cloudwrapper_stateful():


### PR DESCRIPTION
* Add CloudWrapper, wrapping callables in a picklable object (by cloudpickling the callable itself, caching this data)
* Use it to replace explicit cache, see also https://github.com/gavento/orco/blob/cloudpickle-wrapper/orco/builder.py#L43
* Make Builder and Entry picklable (CloudWrapper) and hashable
* Pass Builder and Entry to `_run_job` (to another process)
* Split `_run_job` into smaller functions (it would be better to pass Job there, but it contains the entire graph for now)
* Extract the (partial) running of generator/normal compute fn from 2 places into general `Builder.run_with_args`.
* Extend CLI to accept cfggen language (viz `make test_adder`)

The `tournament` example is currently failing with `Can't pickle <class '__main__.Player'>: it's not the same object as __main__.Player` - for now unresolved, but almost certainly related to subprocesses + maybe cloudpickle.
